### PR TITLE
Improve silent push

### DIFF
--- a/NotifyMe/Logic/Push/UBPush/UBPushManager.swift
+++ b/NotifyMe/Logic/Push/UBPush/UBPushManager.swift
@@ -100,6 +100,9 @@ open class UBPushManager: NSObject {
         self.pushRegistrationManager = pushRegistrationManager
         self.pushRegistrationManager.sendPushRegistrationIfOutdated()
         self.pushHandler.handleLaunchOptions(launchOptions)
+
+        // Request APNS token on startup
+        registerForPushNotification()
     }
 
     /// Needs to be called upon `applicationDidBecomeActiveNotification`
@@ -109,6 +112,16 @@ open class UBPushManager: NSObject {
     }
 
     // MARK: - Push Permission Request Flow
+
+    /// Requests APNS token (if .authorized)
+    ///
+    private func registerForPushNotification() {
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            if settings.authorizationStatus == .authorized {
+                DispatchQueue.main.async { UIApplication.shared.registerForRemoteNotifications() }
+            }
+        }
+    }
 
     /// Requests push permissions
     ///


### PR DESCRIPTION
This PR changes the following silent push related behaviour:
- Fix a problem where the app and request was suspended in the background while syncing during background push (content-available)
- request/update APNS token on app start (if user already authorized app)